### PR TITLE
upgrade elasticsearch, kibana to 8.10.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         condition: service_healthy
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.4
     environment:
       - cluster.name=parsedmarc
       - discovery.type=single-node
@@ -59,7 +59,7 @@ services:
         condition: service_started
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.18
+    image: docker.elastic.co/kibana/kibana:8.10.4
     environment:
       - elasticsearch.hosts=http://elasticsearch:9200
       - telemetry.enabled=false


### PR DESCRIPTION
this allows the docker container to work with the newest dashboard file from domainaware: https://github.com/domainaware/parsedmarc/blob/master/kibana/export.ndjson

See also https://github.com/patschi/parsedmarc-dockerized/issues/39