### PR TITLE
Update docker-compose.yml remove version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
   parsedmarc-init:
     image: patschi/parsedmarc:init
@@ -110,3 +108,4 @@ services:
 networks:
   parsedmarc-network:
     driver: bridge
+


### PR DESCRIPTION
disable warning WARN[0000] docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion